### PR TITLE
Update gradle version to 8.1 so we can use it with JDK 17

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Mon Sep 02 16:43:55 CEST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
We are preparing for this workshop and our team has switched to using Java 17. For this we need the gradle version in the properties file to be updated, please